### PR TITLE
Fixed missing props prefix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -177,7 +177,7 @@ export class RadialProgress extends React.Component<Props, State> {
           position: 'absolute',
           textAlign: 'center',
           color: this.props.ringFgColour,
-          fontSize: `${diameter / fontRatio}px`,
+          fontSize: `${diameter / this.props.fontRatio}px`,
         };
         return (
           <div className="RadialProgressIndicator__label" style={style}>

--- a/stories/radial-progress.js
+++ b/stories/radial-progress.js
@@ -132,6 +132,17 @@ stories
       text={(steps, proportion) => `${Math.floor(proportion * 100)}%`}
     />
   ))
+  .add('Custom font ratio', () => (
+    <RadialProgress
+      steps={5}
+      step={5}
+      width={200}
+      height={200}
+      fontRatio={9}
+      showIntermediateProgress={true}
+      text={(steps, proportion) => `${Math.floor(proportion * 100)}%`}
+    />
+  ))
   .add('Small, with custom text', () => (
     <div style={{ fontWeight: 'bold' }}>
       <RadialProgress

--- a/stories/radial-progress.js
+++ b/stories/radial-progress.js
@@ -138,7 +138,7 @@ stories
       step={5}
       width={200}
       height={200}
-      fontRatio={9}
+      fontRatio={8}
       showIntermediateProgress={true}
       text={(steps, proportion) => `${Math.floor(proportion * 100)}%`}
     />


### PR DESCRIPTION
My bad... I hadn't been able to test in your environment setup and I'd missed the this.props off the front as I've been using the newer react hooks style where you don't use the prefix. This shoudl fix it but please give it a test first!